### PR TITLE
Bump the version of the SourceTextParsers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.0.0",
         "ext-mbstring": "*",
-        "urbanmonastics/sourcetextparser": "^0.4.1"
+        "urbanmonastics/sourcetextparser": "^0.4.3"
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8.35"


### PR DESCRIPTION
while not finished, this allows for the proper removal/ignoring of [iextra] content from source texts